### PR TITLE
Add MintablePureSuperToken

### DIFF
--- a/contracts/MintablePureSuperToken.sol
+++ b/contracts/MintablePureSuperToken.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPLv3
+pragma solidity ^0.8.0;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+import {SuperTokenBase} from "./base/SuperTokenBase.sol";
+
+/// @title Minimal Pure Super Token
+/// @author jtriley.eth changed by shinra-corp.eth
+/// @notice No pre-minted supply.
+contract MintablePureSuperToken is SuperTokenBase, Ownable {
+
+	/// @dev Upgrades the super token with the factory, then initializes.
+    /// @param factory super token factory for initialization
+	/// @param name super token name
+	/// @param symbol super token symbol
+    function initialize(
+        address factory,
+        string memory name,
+        string memory symbol,
+        address minter
+    ) external {
+        _initialize(factory, name, symbol);
+        transferOwnership(minter);
+    }
+
+    /// @notice Mints tokens, only the owner may do this
+    /// @param receiver Receiver of minted tokens
+    /// @param amount Amount to mint
+    function mint(address receiver, uint256 amount) external onlyOwner {
+        _mint(receiver, amount, "");
+    }
+
+}

--- a/contracts/utils/MintablePureSuperTokenDeployer.sol
+++ b/contracts/utils/MintablePureSuperTokenDeployer.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPLv3
+pragma solidity ^0.8.0;
+
+import {MintablePureSuperToken} from "../MintablePureSuperToken.sol";
+
+/// @title Pure Super Token deployment 'Factory'
+/// @author jtriley.eth changed by shinra-corp.eth
+/// @dev Notice this is not the `SuperTokenFactory`, which handles upgrading contracts. This is a
+/// minimal contract simply to deploy, upgrade, and initialize the most minimal super token possible
+contract MintablePureSuperTokenDeployer {
+    
+    /// @dev Emitted when new super token deployed and initialized
+    /// @param newSuperToken New Super Token address
+    event SuperTokenDeployed(address newSuperToken);
+
+    /// @dev Super Token factory address
+    address internal immutable _factory;
+
+    constructor(address factory) {
+        _factory = factory;
+    }
+
+    /// @notice Deploys a new Super Token
+    /// @param name Name for Super Token
+    /// @param symbol Symbol for Super Token
+    /// @return newSuperToken New Super Token address
+    /// @dev Emits `SuperTokenDeployed`
+    function deploySuperToken(
+        string memory name,
+        string memory symbol,
+        address minter
+    ) external returns (address newSuperToken) {
+
+        // (string . address . string) with `abi.encodePacked` is more efficient and prevents a
+        // hashing collision. See https://swcregistry.io/docs/SWC-133
+        newSuperToken = _create2(keccak256(abi.encodePacked(name, msg.sender, symbol)));
+
+        // PureSuperToken has a payable fallback in `Proxy`
+        // Proxy -> UUPSProxy -> SuperTokenBase -> PureSuperToken
+        MintablePureSuperToken(payable(newSuperToken)).initialize(
+            _factory,
+            name,
+            symbol,
+            minter
+        );
+
+        emit SuperTokenDeployed(newSuperToken);
+    }
+
+    /// @dev Creates a new contract with deterministic address using `create2`
+    /// @param salt unique 32 byte salt
+    /// @return newSuperToken Address of newly created super token
+    function _create2(bytes32 salt) internal returns (address newSuperToken) {
+        bytes memory _bytecode = type(MintablePureSuperToken).creationCode;
+        assembly {
+            newSuperToken := create2(
+                0,
+                add(_bytecode, 32),
+                mload(_bytecode),
+                salt
+            )
+        }
+    }
+}

--- a/test/MintablePureSuperTokenDeployer.test.js
+++ b/test/MintablePureSuperTokenDeployer.test.js
@@ -1,0 +1,201 @@
+const { web3tx, toWad } = require("@decentral.ee/web3-helpers")
+const deployFramework = require("@superfluid-finance/ethereum-contracts/scripts/deploy-framework")
+const {
+	builtTruffleContractLoader
+} = require("@superfluid-finance/ethereum-contracts/scripts/libs/common")
+const SuperfluidSDK = require("@superfluid-finance/js-sdk")
+const MintablePureSuperTokenDeployer = artifacts.require(
+	"MintablePureSuperTokenDeployer"
+)
+const MintablePureSuperToken = artifacts.require("MintablePureSuperToken")
+
+contract("MintablePureSuperTokenDeployer", accounts => {
+	const errorHandler = error => {
+		if (error) throw error
+	}
+
+	let sf
+	let cfa
+	let superTokenFactoryAddress
+
+	// deployer contract
+	let mintablePureSuperTokenDeployer
+
+	const [admin, alice, bob] = accounts.slice(0, 3)
+
+	before(
+		async () =>
+			await deployFramework(errorHandler, {
+				web3,
+				from: admin,
+				newTestResolver: true
+			})
+	)
+
+	beforeEach(async () => {
+		sf = new SuperfluidSDK.Framework({
+			web3,
+			version: "test",
+			contractLoader: builtTruffleContractLoader
+		})
+
+		await sf.initialize()
+
+		cfa = sf.agreements.cfa
+
+		superTokenFactoryAddress = await sf.host.getSuperTokenFactory.call()
+
+		mintablePureSuperTokenDeployer = await web3tx(
+			MintablePureSuperTokenDeployer.new,
+			"alice deploys new deployment contract"
+		)(superTokenFactoryAddress)
+	})
+
+	it("can deploy super token", async () => {
+		const tx = await web3tx(
+			mintablePureSuperTokenDeployer.deploySuperToken,
+			"alice deploys pure super token"
+		)("Super Juicy Token", "SJT", alice, { from: alice })
+
+		const address = tx.logs[0].args.newSuperToken
+		const mintablePureSuperToken = await MintablePureSuperToken.at(address)
+
+		const owner = await mintablePureSuperToken.owner.call()
+		assert.equal(owner, alice, "owner should be alice")
+	})
+
+	it("can not deploy twice", async () => {
+		await web3tx(
+			mintablePureSuperTokenDeployer.deploySuperToken,
+			"alice deploys pure super token"
+		)("Super Juicy Token", "SJT", alice, { from: alice })
+
+		try {
+			await web3tx(
+				mintablePureSuperTokenDeployer.deploySuperToken,
+				"alice deploys pure super token again"
+			)("Super Juicy Token", "SJT", alice, { from: alice })
+			throw null
+		} catch (error) {
+			assert(error, "Expected Revert")
+		}
+	})
+
+	it("not owner can't mint new tokens", async () => {
+		const tx = await web3tx(
+			mintablePureSuperTokenDeployer.deploySuperToken,
+			"alice deploys pure super token"
+		)("Super Juicy Token", "SJT", alice, { from: alice })
+
+		const address = tx.logs[0].args.newSuperToken
+		// ISuperToken don't have `mint` method
+		const mintablePureSuperToken = await MintablePureSuperToken.at(address)
+
+		try {
+			await web3tx(mintablePureSuperToken.mint, "alice mints 10 tokens")(
+				alice,
+				"100000000000000000000",
+				{ from: bob }
+			)
+			throw null
+		} catch (error) {
+			assert(error, "Expected Revert")
+		}
+	})
+
+	it("owner can mint new tokens", async () => {
+		const tx = await web3tx(
+			mintablePureSuperTokenDeployer.deploySuperToken,
+			"alice deploys pure super token"
+		)("Super Juicy Token", "SJT", alice, { from: alice })
+
+		const address = tx.logs[0].args.newSuperToken
+		// ISuperToken don't have `mint` method
+		const mintablePureSuperToken = await MintablePureSuperToken.at(address)
+		const superToken = await sf.contracts.ISuperToken.at(address)
+		const aliceBalanceBefore = await superToken.balanceOf.call(alice)
+		assert.equal(aliceBalanceBefore, 0, "alice should have 0 tokens")
+		await web3tx(mintablePureSuperToken.mint, "alice mints 10 tokens")(
+			alice,
+			"100000000000000000000",
+			{ from: alice }
+		)
+		const aliceBalanceAfter = await superToken.balanceOf.call(alice)
+		assert.equal(
+			aliceBalanceAfter.toString(),
+			"100000000000000000000",
+			"alice should have 10 tokens"
+		)
+	})
+
+	it("can deploy same name and symbol from different senders", async () => {
+		const tx0 = await web3tx(
+			mintablePureSuperTokenDeployer.deploySuperToken,
+			"alice deploys pure super token"
+		)("Super Juicy Token", "SJT", alice, { from: alice })
+
+		const tx1 = await web3tx(
+			mintablePureSuperTokenDeployer.deploySuperToken,
+			"bob deploys pure super token"
+		)("Super Juicy Token", "SJT", alice, { from: bob })
+
+		// this is kinda redundant since create2 throws on creating an existing
+		// address but hey, why not just make the assertion anyway
+		assert(tx0.logs[0].args.newSuperToken != tx1.logs[0].args.newSuperToken)
+	})
+
+	it("can not create a hashing collision", async () => {
+		// A hash collision is still feasible, but not in any realistic case,
+		// and to no benefit of an attacker. Since the packed encoding is of
+		// (name . msgSender . symbol), one would need a name and/or symbol at
+		// least 20 bytes long to expose a hash collision.
+
+		await web3tx(
+			mintablePureSuperTokenDeployer.deploySuperToken,
+			"alice deploys pure super token"
+		)("Super Juicy Token", "SJT", alice, { from: alice })
+
+		await web3tx(
+			mintablePureSuperTokenDeployer.deploySuperToken,
+			"alice deploys pure super token"
+		)(
+			"Super Juicy Toke", // shift `n` to symbol
+			"nSJT",
+			alice,
+			{ from: alice }
+		)
+	})
+
+	it("can call agreement with super token", async () => {
+		const tx = await web3tx(
+			mintablePureSuperTokenDeployer.deploySuperToken,
+			"alice deploys pure super token"
+		)("Super Juicy Token", "SJT", alice, { from: alice })
+		const address = tx.logs[0].args.newSuperToken
+
+		// ISuperToken don't have `mint` method
+		const mintablePureSuperToken = await MintablePureSuperToken.at(address)
+		// alice mint 10 tokens
+		await web3tx(mintablePureSuperToken.mint, "alice mints 10 tokens")(
+			alice,
+			"100000000000000000000",
+			{ from: alice }
+		)
+
+		const flowRate = "1000000000000000" // 0.001
+
+		await web3tx(sf.host.callAgreement, "alice creates a flow to bob")(
+			cfa.address,
+			cfa.contract.methods
+				.createFlow(address, bob, flowRate, "0x")
+				.encodeABI(),
+			"0x",
+			{ from: alice }
+		)
+
+		assert.equal(
+			(await cfa.getFlow.call(address, alice, bob)).flowRate.toString(),
+			flowRate
+		)
+	})
+})


### PR DESCRIPTION
Adds `MintablePureSuperToken` contract.

`MintablePureSuperToken` removes initial mint amount to a specific `ownable` `mint` function.

This PR follows the pattern of this repo and the _normal_ `PureSuperToken` with respective deployer contract.
